### PR TITLE
Increase target builds to include 2021 and provide option for using t…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildSearchableOptions {
 patchPluginXml {
   version = project.version
   sinceBuild = '202'
-  untilBuild = '203.*'
+  untilBuild = '211.*'
 }
 
 compileKotlin {

--- a/src/main/kotlin/net/chakmidlot/jetbrains/bigquery/plugin/Settings.kt
+++ b/src/main/kotlin/net/chakmidlot/jetbrains/bigquery/plugin/Settings.kt
@@ -1,5 +1,6 @@
 package net.chakmidlot.jetbrains.bigquery.plugin
 import com.intellij.openapi.options.Configurable
+import com.intellij.ui.components.JBCheckBox
 import javax.swing.*
 import javax.swing.JPanel
 
@@ -13,12 +14,18 @@ class Settings: Configurable {
 
     private var form: JPanel? = null
     private val keyPath = JBTextField()
+    private val applicationDefaultAuthentication = JBCheckBox("Application Default Settings", false)
 
     override fun createComponent(): JComponent {
         val settings = SettingsState.getInstance()
         keyPath.text = settings.state?.keyPath
+        applicationDefaultAuthentication.setSelected(settings.state?.applicationDefaultAuthentication == true)
 
         form = FormBuilder.createFormBuilder()
+            .addLabeledComponent(
+                JBLabel("Use application default settings:"),
+                applicationDefaultAuthentication, false
+            )
             .addLabeledComponent(JBLabel("GCP key path:"), keyPath, 1, false)
             .addComponentFillVertically(JPanel(), 0)
             .panel
@@ -28,15 +35,17 @@ class Settings: Configurable {
 
     override fun isModified(): Boolean {
         val settings = SettingsState.getInstance()
-        return settings.state?.keyPath != this.keyPath.text
+        return settings.state?.keyPath != this.keyPath.text || settings.state?.applicationDefaultAuthentication != this.applicationDefaultAuthentication.isSelected()
     }
 
     override fun apply() {
         val settings = SettingsState.getInstance()
         settings.state?.keyPath = keyPath.text
+        settings.state?.applicationDefaultAuthentication = applicationDefaultAuthentication.isSelected()
+
     }
 
     override fun getDisplayName(): String {
-        return "BigQuery GCP key"
+        return "BigQuery Estimator Setttings"
     }
 }

--- a/src/main/kotlin/net/chakmidlot/jetbrains/bigquery/plugin/SettingsState.kt
+++ b/src/main/kotlin/net/chakmidlot/jetbrains/bigquery/plugin/SettingsState.kt
@@ -28,4 +28,5 @@ class SettingsState : PersistentStateComponent<StateModel> {
 
 data class StateModel (
     var keyPath: String = "",
-)
+    var applicationDefaultAuthentication: Boolean = false,
+    )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,9 @@
         Shows BigQuery query scanned data estimation and approximate cost.
       </p>
       <p>
+        <i You choose to use a GCP service account key, or the application default credentials picked up via
+        GOOGLE_APPLICATION_CREDENTIALS<i>
+        <br>
         <i>Your GCP service account key is used only to send 'dry run' requests to Google cloud API
         and not sent anywhere else</i>
       </p>
@@ -31,13 +34,13 @@
     <group id="BigQueryEstimate">
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
       <action id="MyPlugin.Hello" class="net.chakmidlot.jetbrains.bigquery.plugin.BigQueryDryRun"
-              text="BigQuery estimate" description="Estimates BigQuery data scanned"/>
+              text="BigQuery Estimate" description="Estimates BigQuery data scanned"/>
     </group>
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable parentId="tools" instance="net.chakmidlot.jetbrains.bigquery.plugin.Settings"
-                         id="net.chakmidlot.jetbrains.bigquery.plugin.Settings" displayName="BigQuery GCP key"/>
+                         id="net.chakmidlot.jetbrains.bigquery.plugin.Settings" displayName="BigQuery Estimator Settings"/>
     <applicationService serviceImplementation="net.chakmidlot.jetbrains.bigquery.plugin.SettingsState"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
WHAT
Modified the target builds to allow for latests Intelliij and Datagrip builds.

Added an option to use the Application Default Settings if they are available, I don't use service accounts personally so this is easier for me.

Modified some of the descriptions and menu fields.

WHY
desperately need this plugin as i hate the Google BigQuery web UI :D thanks very much for building it! 
